### PR TITLE
Fix subprocess.mswindows check for Python 3.5

### DIFF
--- a/popenasync.py
+++ b/popenasync.py
@@ -23,7 +23,12 @@ if sys.version_info >= (3,):
 else:
     null_byte = '\x00'
 
-if subprocess.mswindows:
+if hasattr(subprocess, 'mswindows'):
+    mswindows = subprocess.mswindows
+else:
+    mswindows = subprocess._mswindows
+
+if mswindows:
     if sys.version_info >= (3,):
         # Test date should be in ascii.
         def encode(s):
@@ -142,7 +147,7 @@ class Popen(subprocess.Popen):
         getattr(self, which).close()
         setattr(self, which, None)
     
-    if subprocess.mswindows:
+    if mswindows:
         def kill(self):
             # Recipes
             #http://me.in-berlin.de/doc/python/faq/windows.html#how-do-i-emulate-os-kill-in-windows

--- a/popenasync.py
+++ b/popenasync.py
@@ -23,10 +23,7 @@ if sys.version_info >= (3,):
 else:
     null_byte = '\x00'
 
-if hasattr(subprocess, 'mswindows'):
-    mswindows = subprocess.mswindows
-else:
-    mswindows = subprocess._mswindows
+mswindows = (sys.platform == "win32")
 
 if mswindows:
     if sys.version_info >= (3,):


### PR DESCRIPTION
They renamed the `mswindows` attribute of `subprocess` to `_mswindows` in Python 3.5